### PR TITLE
Improve Method Name in AppointmentApi

### DIFF
--- a/src/FactroApiClient/Appointment/AppointmentApi.cs
+++ b/src/FactroApiClient/Appointment/AppointmentApi.cs
@@ -112,7 +112,7 @@ namespace FactroApiClient.Appointment
 
         /// <inheritdoc/>
         /// <exception cref="ArgumentNullException"><paramref name="appointmentId"/> is null, empty or whitespace.</exception>
-        public async Task<GetAppointmentByIdResponse> GetAppointmentAsync(string appointmentId)
+        public async Task<GetAppointmentByIdResponse> GetAppointmentByIdAsync(string appointmentId)
         {
             if (string.IsNullOrWhiteSpace(appointmentId))
             {

--- a/src/FactroApiClient/Appointment/IAppointmentApi.cs
+++ b/src/FactroApiClient/Appointment/IAppointmentApi.cs
@@ -31,7 +31,7 @@ namespace FactroApiClient.Appointment
         /// </summary>
         /// <param name="appointmentId">The id of the appointment that should be fetched.</param>
         /// <returns>Returns the fetched appointment.</returns>
-        public Task<GetAppointmentByIdResponse> GetAppointmentAsync(string appointmentId);
+        public Task<GetAppointmentByIdResponse> GetAppointmentByIdAsync(string appointmentId);
 
         /// <summary>
         /// Updates the appointment with the given appointment id.

--- a/tests/FactroApiClient.IntegrationTests/AppointmentApi/AppointmentApiTests_GetAppointmentAsync.cs
+++ b/tests/FactroApiClient.IntegrationTests/AppointmentApi/AppointmentApiTests_GetAppointmentAsync.cs
@@ -29,7 +29,7 @@ namespace FactroApiClient.IntegrationTests.AppointmentApi
             var fetchedAppointment = new GetAppointmentByIdResponse();
 
             // Act
-            Func<Task> act = async () => fetchedAppointment = await appointmentApi.GetAppointmentAsync(existingAppointment.Id);
+            Func<Task> act = async () => fetchedAppointment = await appointmentApi.GetAppointmentByIdAsync(existingAppointment.Id);
 
             // Assert
             await act.Should().NotThrowAsync();
@@ -46,7 +46,7 @@ namespace FactroApiClient.IntegrationTests.AppointmentApi
             var fetchedAppointment = new GetAppointmentByIdResponse();
 
             // Act
-            Func<Task> act = async () => fetchedAppointment = await appointmentApi.GetAppointmentAsync(Guid.NewGuid().ToString());
+            Func<Task> act = async () => fetchedAppointment = await appointmentApi.GetAppointmentByIdAsync(Guid.NewGuid().ToString());
 
             // Assert
             await act.Should().NotThrowAsync();

--- a/tests/FactroApiClient.UnitTests/Appointment/AppointmentApiTests_GetAppointmentAsync.cs
+++ b/tests/FactroApiClient.UnitTests/Appointment/AppointmentApiTests_GetAppointmentAsync.cs
@@ -39,7 +39,7 @@ namespace FactroApiClient.UnitTests.Appointment
             var result = new GetAppointmentByIdResponse();
 
             // Act
-            Func<Task> act = async () => result = await appointmentApi.GetAppointmentAsync(appointmentId);
+            Func<Task> act = async () => result = await appointmentApi.GetAppointmentByIdAsync(appointmentId);
 
             // Assert
             await act.Should().NotThrowAsync();
@@ -55,7 +55,7 @@ namespace FactroApiClient.UnitTests.Appointment
             var appointmentApi = this.fixture.GetAppointmentApi();
 
             // Act
-            Func<Task> act = async () => await appointmentApi.GetAppointmentAsync(appointmentId);
+            Func<Task> act = async () => await appointmentApi.GetAppointmentByIdAsync(appointmentId);
 
             // Assert
             await act.Should().ThrowAsync<ArgumentNullException>();
@@ -78,7 +78,7 @@ namespace FactroApiClient.UnitTests.Appointment
             var result = new GetAppointmentByIdResponse();
 
             // Act
-            Func<Task> act = async () => result = await appointmentApi.GetAppointmentAsync(Guid.NewGuid().ToString());
+            Func<Task> act = async () => result = await appointmentApi.GetAppointmentByIdAsync(Guid.NewGuid().ToString());
 
             // Assert
             await act.Should().NotThrowAsync();


### PR DESCRIPTION
**Description**
This pull request changes `GetAppointmentAsync` to `GetAppointmentByIdAsync` of the AppointmentApi interface to make the name more speaking.
