### PR TITLE
Remove Integration Tests From Ci Workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -47,13 +47,6 @@ jobs:
         run: dotnet test -c Release --no-restore --no-build
         working-directory: ./tests/FactroApiClient.UnitTests
 
-      - name: Test sources (Integration Tests)
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
-        run: dotnet test -c Release --no-restore --no-build
-        working-directory: ./tests/FactroApiClient.IntegrationTests
-        env:
-          FactroApiClient__ApiToken: ${{ secrets.FACTRO_API_TOKEN }}
-
       - name: Set git config
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         run: |


### PR DESCRIPTION
**Description**
This pull request remove the execution of integration tests from the CI Workflow.

**Issues**
