### PR TITLE
Package API - Comments - Unit Tests

### DIFF
--- a/src/FactroApiClient/Package/IPackageApi.cs
+++ b/src/FactroApiClient/Package/IPackageApi.cs
@@ -31,7 +31,7 @@ namespace FactroApiClient.Package
 
         public Task<IEnumerable<GetPackageCommentPayload>> GetCommentsOfPackageAsync(string projectId, string packageId);
 
-        public Task<DeletePackageCommentResponse> DeletePackageCommentCommentAsync(string projectId, string packageId, string commentId);
+        public Task<DeletePackageCommentResponse> DeletePackageCommentAsync(string projectId, string packageId, string commentId);
 
         // Association
         public Task SetPackageCompanyAsync(string projectId, string packageId, SetCompanyAssociationRequest setCompanyAssociationRequest);

--- a/src/FactroApiClient/Package/PackageApi.cs
+++ b/src/FactroApiClient/Package/PackageApi.cs
@@ -386,7 +386,7 @@ namespace FactroApiClient.Package
             }
         }
 
-        public async Task<DeletePackageCommentResponse> DeletePackageCommentCommentAsync(string projectId, string packageId, string commentId)
+        public async Task<DeletePackageCommentResponse> DeletePackageCommentAsync(string projectId, string packageId, string commentId)
         {
             if (string.IsNullOrWhiteSpace(projectId))
             {

--- a/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_CreatePackageCommentAsync.cs
+++ b/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_CreatePackageCommentAsync.cs
@@ -1,0 +1,186 @@
+namespace FactroApiClient.UnitTests.PackageApi
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using FactroApiClient.Package.Contracts;
+    using FactroApiClient.Package.Contracts.Comment;
+    using FactroApiClient.Project.Contracts.Base;
+    using FactroApiClient.SharedContracts;
+
+    using FluentAssertions;
+
+    using Newtonsoft.Json;
+
+    using Xunit;
+
+    public partial class PackageApiTests
+    {
+        [Fact]
+        public async Task CreatePackageCommentAsync_ValidRequest_ShouldReturnCreatedPackageComment()
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var text = Guid.NewGuid().ToString();
+
+            var createPackageCommentRequest = new CreatePackageCommentRequest(text);
+
+            var expectedPackageComment = new CreatePackageCommentResponse
+            {
+                Text = text,
+            };
+
+            var expectedResponseContent =
+                new StringContent(JsonConvert.SerializeObject(expectedPackageComment, this.fixture.JsonSerializerSettings));
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                Content = expectedResponseContent,
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            var createPackageCommentResponse = default(CreatePackageCommentResponse);
+
+            // Act
+            Func<Task> act = async () => createPackageCommentResponse = await packageApi.CreatePackageCommentAsync(existingProject.Id, existingPackage.Id, createPackageCommentRequest);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+
+            createPackageCommentResponse.Should().BeEquivalentTo(expectedPackageComment);
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidProjectIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task CreatePackageCommentAsync_InvalidProjectId_ShouldThrowArgumentNullException(string projectId)
+        {
+            // Arrange
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var text = Guid.NewGuid().ToString();
+
+            var createPackageCommentRequest = new CreatePackageCommentRequest(text);
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.CreatePackageCommentAsync(projectId, existingPackage.Id, createPackageCommentRequest);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidPackageIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task CreatePackageCommentAsync_InvalidPackageId_ShouldThrowArgumentNullException(string packageId)
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var text = Guid.NewGuid().ToString();
+
+            var createPackageCommentRequest = new CreatePackageCommentRequest(text);
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.CreatePackageCommentAsync(existingProject.Id, packageId, createPackageCommentRequest);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task CreatePackageCommentAsync_NullRequestModel_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.CreatePackageCommentAsync(existingProject.Id, existingPackage.Id, createPackageCommentRequest: null);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task CreatePackageCommentAsync_NullRequestModelText_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var createPackageCommentRequest = new CreatePackageCommentRequest(text: null);
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.CreatePackageCommentAsync(existingProject.Id, existingPackage.Id, createPackageCommentRequest);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task CreatePackageCommentAsync_UnsuccessfulRequest_ShouldThrowFactroApiException()
+        {
+            // Arrange
+            var projectId = Guid.NewGuid().ToString();
+            var packageId = Guid.NewGuid().ToString();
+
+            var createPackageCommentRequest = new CreatePackageCommentRequest(Guid.NewGuid().ToString());
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                RequestMessage = new HttpRequestMessage
+                {
+                    RequestUri = new Uri("http://www.mock-web-address.com"),
+                },
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            // Act
+            Func<Task> act = async () => await packageApi.CreatePackageCommentAsync(projectId, packageId, createPackageCommentRequest);
+
+            // Assert
+            await act.Should().ThrowAsync<FactroApiException>();
+        }
+    }
+}

--- a/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_DeletePackageCommentAsync.cs
+++ b/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_DeletePackageCommentAsync.cs
@@ -1,0 +1,187 @@
+namespace FactroApiClient.UnitTests.PackageApi
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using FactroApiClient.Package.Contracts;
+    using FactroApiClient.Package.Contracts.Comment;
+    using FactroApiClient.Project.Contracts.Base;
+    using FactroApiClient.SharedContracts;
+
+    using FluentAssertions;
+
+    using Newtonsoft.Json;
+
+    using Xunit;
+
+    public partial class PackageApiTests
+    {
+        [Fact]
+        public async Task DeletePackageCommentAsync_ValidRequest_ShouldReturnDeletedPackageComment()
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackageComments = new List<GetPackageCommentPayload>
+            {
+                new GetPackageCommentPayload
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    TaskPackageId = existingPackage.Id,
+                },
+            };
+
+            var expectedPackageComment =
+                existingPackageComments.First(comment => comment.TaskPackageId == existingPackage.Id);
+
+            var expectedResponseContent =
+                new StringContent(JsonConvert.SerializeObject(expectedPackageComment, this.fixture.JsonSerializerSettings));
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                Content = expectedResponseContent,
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            var deletePackageCommentResponse = default(DeletePackageCommentResponse);
+
+            // Act
+            Func<Task> act = async () => deletePackageCommentResponse = await packageApi.DeletePackageCommentAsync(existingProject.Id, existingPackage.Id, expectedPackageComment.Id);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+
+            deletePackageCommentResponse.Should().BeEquivalentTo(expectedPackageComment);
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidProjectIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task DeletePackageCommentAsync_InvalidProjectId_ShouldThrowArgumentNullException(string projectId)
+        {
+            // Arrange
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackageComments = new List<GetPackageCommentPayload>
+            {
+                new GetPackageCommentPayload
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    TaskPackageId = existingPackage.Id,
+                },
+            };
+
+            var expectedPackageComment =
+                existingPackageComments.First(comment => comment.TaskPackageId == existingPackage.Id);
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.DeletePackageCommentAsync(projectId, existingPackage.Id, expectedPackageComment.Id);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidPackageIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task DeletePackageCommentAsync_InvalidPackageId_ShouldThrowArgumentNullException(string packageId)
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackageComments = new List<GetPackageCommentPayload>
+            {
+                new GetPackageCommentPayload
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    TaskPackageId = existingPackage.Id,
+                },
+            };
+
+            var expectedPackageComment =
+                existingPackageComments.First(comment => comment.TaskPackageId == existingPackage.Id);
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.DeletePackageCommentAsync(existingProject.Id, packageId, expectedPackageComment.Id);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidPackageCommentIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task DeletePackageCommentAsync_InvalidCommentId_ShouldThrowArgumentNullException(string packageCommentId)
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.DeletePackageCommentAsync(existingProject.Id, existingPackage.Id, packageCommentId);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task DeletePackageCommentAsync_UnsuccessfulRequest_ShouldThrowFactroApiException()
+        {
+            // Arrange
+            var projectId = Guid.NewGuid().ToString();
+            var packageId = Guid.NewGuid().ToString();
+            var commentId = Guid.NewGuid().ToString();
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                RequestMessage = new HttpRequestMessage
+                {
+                    RequestUri = new Uri("http://www.mock-web-address.com"),
+                },
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            // Act
+            Func<Task> act = async () => await packageApi.DeletePackageCommentAsync(projectId, packageId, commentId);
+
+            // Assert
+            await act.Should().ThrowAsync<FactroApiException>();
+        }
+    }
+}

--- a/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_GetCommentsOfPackageAsync.cs
+++ b/tests/FactroApiClient.UnitTests/PackageApi/PackageApiTests_GetCommentsOfPackageAsync.cs
@@ -1,0 +1,136 @@
+namespace FactroApiClient.UnitTests.PackageApi
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using FactroApiClient.Package.Contracts;
+    using FactroApiClient.Package.Contracts.Comment;
+    using FactroApiClient.Project.Contracts.Base;
+    using FactroApiClient.SharedContracts;
+
+    using FluentAssertions;
+
+    using Newtonsoft.Json;
+
+    using Xunit;
+
+    public partial class PackageApiTests
+    {
+        [Fact]
+        public async Task GetCommentsOfPackageAsync_ValidRequest_ShouldReturnCommentsOfPackage()
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var existingPackageComments = new List<GetPackageCommentPayload>
+            {
+                new GetPackageCommentPayload
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    TaskPackageId = existingPackage.Id,
+                },
+                new GetPackageCommentPayload
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    TaskPackageId = existingPackage.Id,
+                },
+            };
+
+            var expectedPackageComments = existingPackageComments.Where(comment => comment.TaskPackageId == existingPackage.Id);
+
+            var expectedResponseContent = new StringContent(JsonConvert.SerializeObject(expectedPackageComments, this.fixture.JsonSerializerSettings));
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                Content = expectedResponseContent,
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            var getCommentsOfPackageResponse = default(IEnumerable<GetPackageCommentPayload>);
+
+            // Act
+            Func<Task> act = async () => getCommentsOfPackageResponse = await packageApi.GetCommentsOfPackageAsync(existingProject.Id, existingPackage.Id);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+
+            getCommentsOfPackageResponse.Should().BeEquivalentTo(existingPackageComments);
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidProjectIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task GetCommentsOfPackageAsync_InvalidProjectId_ShouldThrowArgumentNullException(string projectId)
+        {
+            // Arrange
+            var existingPackage = new GetPackagePayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.GetCommentsOfPackageAsync(projectId, existingPackage.Id);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(PackageApiTestFixture.InvalidPackageIds), MemberType = typeof(PackageApiTestFixture))]
+        public async Task GetCommentsOfPackageAsync_InvalidPackageId_ShouldThrowArgumentNullException(string packageId)
+        {
+            // Arrange
+            var existingProject = new GetProjectPayload
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+
+            var packageApi = this.fixture.GetPackageApi();
+
+            // Act
+            Func<Task> act = async () => await packageApi.GetCommentsOfPackageAsync(existingProject.Id, packageId);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task GetCommentsOfPackageAsync_UnsuccessfulRequest_ShouldThrowFactroApiException()
+        {
+            // Arrange
+            var projectId = Guid.NewGuid().ToString();
+            var packageId = Guid.NewGuid().ToString();
+
+            var expectedResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                RequestMessage = new HttpRequestMessage
+                {
+                    RequestUri = new Uri("http://www.mock-web-address.com"),
+                },
+            };
+
+            var packageApi = this.fixture.GetPackageApi(expectedResponse);
+
+            // Act
+            Func<Task> act = async () => await packageApi.GetCommentsOfPackageAsync(projectId, packageId);
+
+            // Assert
+            await act.Should().ThrowAsync<FactroApiException>();
+        }
+    }
+}


### PR DESCRIPTION
**Description**
This pull request adds the unit tests for the comments functionalities of the package API.

**Changes:**
1. Fix wrong method name `DeletePackageCommentCommentAsync` -> `DeletePackageCommentAsync`

**Issues**
- closed #108 
