### PR TITLE
Improve Continuous Integration

### DIFF
--- a/.github/workflows/integration_test_ci.yml
+++ b/.github/workflows/integration_test_ci.yml
@@ -1,0 +1,42 @@
+name: Integration Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - "main"
+      - "beta"
+      - "develop"
+
+env:
+  CI_TOOLS_VERSION: "3.2.0-beta.2"
+
+jobs:
+  run-integration-tests:
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    name: Run integration tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup .NET Core 3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.300
+
+      - name: Add nuget source
+        run: dotnet nuget add source "${{ secrets.NUGET_PUSH_SOURCE }}" -n "github" -u "${{ secrets.PACKAGES_USER }}" -p "${{ secrets.PACKAGES_TOKEN }}" --store-password-in-clear-text
+
+      - name: Restore dependencies
+        run: dotnet restore ./FactroApiClient.sln
+
+      - name: Build sources
+        run: dotnet build -c Release --no-restore
+
+      - name: Test sources (Integration Tests)
+        run: dotnet test -c Release --no-restore --no-build
+        working-directory: ./tests/FactroApiClient.IntegrationTests

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -1,20 +1,21 @@
-name: FactroApiClient CI
+name: Release CI
 
 on:
   push:
     branches:
-      - "*"
-      - "*/*"
+      - "main"
+      - "beta"
+      - "develop"
 
 env:
   CI_TOOLS_VERSION: "3.2.0-beta.2"
 
 jobs:
-  build-sources:
+  create-release:
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    name: Build Sources
+    name: Create Release
     runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
@@ -26,35 +27,28 @@ jobs:
         with:
           dotnet-version: 3.1.300
 
+      - name: Add nuget source
+        run: dotnet nuget add source "${{ secrets.NUGET_PUSH_SOURCE }}" -n "github" -u "${{ secrets.PACKAGES_USER }}" -p "${{ secrets.PACKAGES_TOKEN }}" --store-password-in-clear-text
+
       - name: Restore dependencies
-        run: |
-          dotnet nuget add source "${{ secrets.NUGET_PUSH_SOURCE }}" -n "github" -u "${{ secrets.PACKAGES_USER }}" -p "${{ secrets.PACKAGES_TOKEN }}" --store-password-in-clear-text
-          dotnet restore ./FactroApiClient.sln
+        run: dotnet restore ./FactroApiClient.sln
 
       - name: Install CI-Tools
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         run: sudo npm install -g @process-engine/ci_tools@${{ env.CI_TOOLS_VERSION }}
 
       - name: Prepare version
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         run: ci_tools prepare-version --allow-dirty-workdir --mode dotnet
         working-directory: ./src/FactroApiClient
 
       - name: Build sources
         run: dotnet build -c Release --no-restore
 
-      - name: Test sources (Unit Tests)
-        run: dotnet test -c Release --no-restore --no-build
-        working-directory: ./tests/FactroApiClient.UnitTests
-
       - name: Set git config
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         run: |
           git config user.name "${{ secrets.CI_USER_NAME }}"
           git config user.email "${{ secrets.CI_USER_EMAIL }}"
 
       - name: Commit & tag version
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         env:
           GH_USER: ${{ secrets.CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.CI_USER_TOKEN }}
@@ -64,7 +58,6 @@ jobs:
         working-directory: ./src/FactroApiClient
 
       - name: Create github release
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         env:
           GH_USER: ${{ secrets.CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.CI_USER_TOKEN }}
@@ -72,7 +65,6 @@ jobs:
         working-directory: ./src/FactroApiClient
 
       - name: Push NuGet packages
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
         run: |
           mkdir -p artifacts/nuget
           find ./src -name '*.nupkg' -exec cp {} ./artifacts/nuget \;

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -1,0 +1,41 @@
+name: Unit Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - "*"
+      - "*/*"
+
+env:
+  CI_TOOLS_VERSION: "3.2.0-beta.2"
+
+jobs:
+  run-unit-tests:
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    name: Run unit tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup .NET Core 3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.300
+
+      - name: Add nuget source
+        run: dotnet nuget add source "${{ secrets.NUGET_PUSH_SOURCE }}" -n "github" -u "${{ secrets.PACKAGES_USER }}" -p "${{ secrets.PACKAGES_TOKEN }}" --store-password-in-clear-text
+
+      - name: Restore dependencies
+        run: dotnet restore ./FactroApiClient.sln
+
+      - name: Build sources
+        run: dotnet build -c Release --no-restore
+
+      - name: Test sources (Unit Tests)
+        run: dotnet test -c Release --no-restore --no-build
+        working-directory: ./tests/FactroApiClient.UnitTests


### PR DESCRIPTION
**Description**
This pull request improves the usage of GitHub Actions workflows.
This improved usage should reduce the CI runtime.

**Changes**
1. Adjust the main workflow to only run if an actual release should be created.
1. Create a workflow to run unit tests scheduled every day and on push on any branch.
1. Create a workflow to run integration tests scheduled every day and on push on primary branches (`main`, `beta`, `develop`)